### PR TITLE
feat(dolphin): add productivity enhancements and service menus

### DIFF
--- a/configs/dolphin/dolphinrc
+++ b/configs/dolphin/dolphinrc
@@ -4,27 +4,32 @@ MenuBar=Disabled
 update_info=dolphin_detailsmodesettings.upd:rename-leading-padding
 
 [DetailsMode]
-PreviewSize=16
+ExpandableFolders=true
+PreviewSize=22
+SidePadding=16
 
 [General]
 EditableUrl=true
+FilterBar=true
+HiddenFilesShown=true
 ShowFullPath=true
 ShowSelectionToggle=false
 ShowStatusBar=FullWidth
 ShowZoomSlider=true
+SplitView=true
 Version=202
 ViewPropsTimestamp=2023,4,26,16,58,48.324
 
 [IconsMode]
-MaximumTextLines=1
-PreviewSize=80
+MaximumTextLines=2
+PreviewSize=128
 
 [InformationPanel]
 dateFormat=ShortFormat
 
 [KFileDialog Settings]
 Places Icons Auto-resize=false
-Places Icons Static Size=16
+Places Icons Static Size=22
 
 [KPropertiesDialog]
 2560x1080 screen: Window-Maximized=true
@@ -40,6 +45,7 @@ ToolButtonStyle=IconOnly
 IconSize=16
 
 [PreviewSettings]
+MaximumRemoteSize=10485760
 Plugins=appimagethumbnail,audiothumbnail,comicbookthumbnail,cursorthumbnail,djvuthumbnail,ebookthumbnail,exrthumbnail,imagethumbnail,jpegthumbnail,kraorathumbnail,windowsexethumbnail,windowsimagethumbnail,opendocumentthumbnail,svgthumbnail,ffmpegthumbs
 
 [Toolbar mainToolBar]

--- a/configs/dolphin/servicemenus/copy-path.desktop
+++ b/configs/dolphin/servicemenus/copy-path.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Type=Service
+MimeType=all/allfiles;inode/directory;
+Actions=copyPath;copyPathQuoted
+
+[Desktop Action copyPath]
+Name=Copy Path
+Icon=edit-copy
+Exec=bash -c 'echo -n "%f" | wl-copy'
+
+[Desktop Action copyPathQuoted]
+Name=Copy Path (Quoted)
+Icon=edit-copy
+Exec=bash -c 'echo -n "\"%f\"" | wl-copy'

--- a/configs/dolphin/servicemenus/git-actions.desktop
+++ b/configs/dolphin/servicemenus/git-actions.desktop
@@ -1,0 +1,19 @@
+[Desktop Entry]
+Type=Service
+MimeType=inode/directory;
+Actions=gitStatus;gitLog;gitLazygit
+
+[Desktop Action gitStatus]
+Name=Git Status
+Icon=git
+Exec=ghostty -e bash -c 'cd "%f" && git status; read -p "Press Enter to close..."'
+
+[Desktop Action gitLog]
+Name=Git Log (Graph)
+Icon=git
+Exec=ghostty -e bash -c 'cd "%f" && git log --oneline --graph -20; read -p "Press Enter to close..."'
+
+[Desktop Action gitLazygit]
+Name=Open in Lazygit
+Icon=git
+Exec=ghostty -e bash -c 'cd "%f" && lazygit'

--- a/configs/dolphin/servicemenus/open-in-code.desktop
+++ b/configs/dolphin/servicemenus/open-in-code.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Type=Service
+MimeType=inode/directory;text/*;application/json;application/javascript;application/x-shellscript;
+Actions=openInVSCode;openInCursor
+
+[Desktop Action openInVSCode]
+Name=Open in VS Code
+Icon=visual-studio-code
+Exec=code %f
+
+[Desktop Action openInCursor]
+Name=Open in Cursor
+Icon=cursor
+Exec=cursor %f

--- a/configs/dolphin/servicemenus/open-in-nvim.desktop
+++ b/configs/dolphin/servicemenus/open-in-nvim.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Service
+MimeType=text/*;application/json;application/javascript;application/x-shellscript;application/xml;application/x-yaml;
+Actions=openInNvim
+
+[Desktop Action openInNvim]
+Name=Open in Neovim
+Icon=nvim
+Exec=ghostty -e nvim %f

--- a/configs/dolphin/servicemenus/open-terminal-here.desktop
+++ b/configs/dolphin/servicemenus/open-terminal-here.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Service
+MimeType=inode/directory;
+Actions=openTerminalHere
+
+[Desktop Action openTerminalHere]
+Name=Open Terminal Here
+Icon=utilities-terminal
+Exec=ghostty --working-directory=%f

--- a/script/dolphin/linux/setup.sh
+++ b/script/dolphin/linux/setup.sh
@@ -6,7 +6,68 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 source "$SCRIPT_DIR/../../common/log.sh"
 source "$SCRIPT_DIR/../../common/symlink.sh"
 
+# ─────────────────────────────────────────────────────────────
+# Install dolphin-plugins for Git integration and extras
+# ─────────────────────────────────────────────────────────────
+if command -v pacman &>/dev/null; then
+    if ! pacman -Qi dolphin-plugins &>/dev/null; then
+        info "Installing dolphin-plugins for Git integration..."
+        sudo pacman -S --noconfirm dolphin-plugins
+        success "dolphin-plugins installed"
+    else
+        info "dolphin-plugins already installed"
+    fi
+fi
+
+# Ensure wl-copy is available for clipboard service menus (Wayland)
+if command -v pacman &>/dev/null; then
+    if ! command -v wl-copy &>/dev/null; then
+        info "Installing wl-clipboard for copy-path service menu..."
+        sudo pacman -S --noconfirm wl-clipboard
+        success "wl-clipboard installed"
+    fi
+fi
+
+# ─────────────────────────────────────────────────────────────
+# Symlink dolphinrc configuration
+# ─────────────────────────────────────────────────────────────
 DOLPHIN_SOURCE="$SCRIPT_DIR/../../../configs/dolphin/dolphinrc"
 DOLPHIN_TARGET="$HOME/.config/dolphinrc"
 
 link_file "$DOLPHIN_SOURCE" "$DOLPHIN_TARGET"
+
+# ─────────────────────────────────────────────────────────────
+# Symlink service menus (right-click context actions)
+# ─────────────────────────────────────────────────────────────
+SERVICEMENUS_SOURCE="$SCRIPT_DIR/../../../configs/dolphin/servicemenus"
+SERVICEMENUS_TARGET="$HOME/.local/share/kio/servicemenus"
+
+# Create parent directory if needed
+mkdir -p "$(dirname "$SERVICEMENUS_TARGET")"
+
+# Symlink each service menu file individually (allows mixing with other service menus)
+if [ -d "$SERVICEMENUS_SOURCE" ]; then
+    mkdir -p "$SERVICEMENUS_TARGET"
+    for menu_file in "$SERVICEMENUS_SOURCE"/*.desktop; do
+        if [ -f "$menu_file" ]; then
+            filename=$(basename "$menu_file")
+            link_file "$menu_file" "$SERVICEMENUS_TARGET/$filename"
+        fi
+    done
+    success "Service menus linked"
+fi
+
+# ─────────────────────────────────────────────────────────────
+# Rebuild KDE service menu cache
+# ─────────────────────────────────────────────────────────────
+if command -v kbuildsycoca6 &>/dev/null; then
+    info "Rebuilding KDE service cache..."
+    kbuildsycoca6 --noincremental 2>/dev/null || true
+    success "Service cache rebuilt"
+elif command -v kbuildsycoca5 &>/dev/null; then
+    info "Rebuilding KDE service cache..."
+    kbuildsycoca5 --noincremental 2>/dev/null || true
+    success "Service cache rebuilt"
+fi
+
+info "Dolphin setup complete! Restart Dolphin to apply changes."


### PR DESCRIPTION
Enable power-user defaults: split view, hidden files, filter bar, expandable folders, and larger previews. Add right-click service menus for Neovim, Ghostty terminal, Lazygit, VS Code/Cursor, and path copying. Setup script now installs dolphin-plugins for Git integration and symlinks service menus to KDE location.