### PR TITLE
feat(claude): cmux sidebar PR-approval pill + task progress bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ configs/hyde/themes/
 # Compiled Go binaries
 bin/nxps
 nxps
+
+# Python bytecode cache (e.g. from configs/claude/scripts)
+__pycache__/
+*.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,6 +303,34 @@ bash configs/claude/statusline_demo.sh   # visually confirm each variation still
 
 If you add a new field, branch/PR/worktree case, or line-3 indicator, add a corresponding test in `statusline_test.sh` and a scenario in `statusline_demo.sh` before considering the change complete. The demo doubles as living documentation for every supported rendering.
 
+### cmux Sidebar Hooks (macOS)
+
+`configs/claude/scripts/` holds Claude Code hook scripts that drive the cmux
+sidebar (symlinked to `~/.claude/scripts` by `script/claude/setup.sh`; wired in
+`configs/claude/settings.json`). Shared identity/guard logic lives in
+`cmux_common.py` — `resolve_workspace()` maps this session to its workspace UUID,
+and `alive()` makes every script a cheap no-op when cmux isn't running (it
+short-circuits on socket existence, so a closed cmux or a non-macOS box spawns no
+subprocess).
+
+- `cmux-title.py` — workspace title (`NES-#### · <topic>`)
+- `cmux-pr.py` — `✓ Approved #<n>` status pill when the branch's PR is approved
+  (CI is left to cmux's native PR watcher); `SessionStart`/`Stop`/post-push
+- `cmux-progress.py` — sidebar progress bar from `TodoWrite` (`completed/total`);
+  `PostToolUse(TodoWrite)` sets it, `SessionStart` clears it
+
+Each pill/bar script exposes a pure mapping function plus a hidden `--emit` mode
+so the logic is unit-testable without cmux or the network. **When modifying
+`cmux-pr.py` or `cmux-progress.py`, run:**
+
+```bash
+bash configs/claude/scripts/cmux_pr_test.sh        # must end with "All N tests passed"
+bash configs/claude/scripts/cmux_progress_test.sh  # must end with "All N tests passed"
+bash configs/claude/scripts/cmux_status_demo.sh    # (inside cmux) visually confirm each pill/bar
+```
+
+Add a test case for any new state mapping before considering the change complete.
+
 ### Touch ID Command Gate (macOS)
 
 AI-initiated sensitive Bash commands require biometric approval via a Claude Code `PreToolUse` hook:

--- a/configs/claude/scripts/cmux-pr.py
+++ b/configs/claude/scripts/cmux-pr.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Show a cmux sidebar pill when this branch's PR is approved.
+
+CI status is intentionally left to cmux's native PR watcher (it already
+populates the sidebar `pr` field). This script owns the one signal the native
+watcher doesn't surface: that a human approved the PR.
+
+  reviewDecision == APPROVED  ->  set-status review "✓ Approved #<n>"
+  anything else / no PR       ->  clear-status review   (idempotent — no stale pill)
+
+Triggers (see settings.json):
+  SessionStart / Stop                       — refresh at session start + turn-end
+  PostToolUse(Bash) after git push / gh pr  — refresh right after you push/open a PR
+
+Cosmetic: every failure path exits 0; it must never break a session.
+"""
+import sys, os, json
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import cmux_common as cx
+
+STATUS_KEY = "review"
+APPROVED = "APPROVED"
+PILL_ICON = "checkmark.seal.fill"
+PILL_COLOR = "#3FB950"  # GitHub green
+PILL_PRIORITY = "20"
+
+
+def review_pill(review_decision, number):
+    """Pure mapping: PR review state -> the cmux action to take.
+
+    Returns a dict the caller turns into a `cmux` invocation, or one that clears
+    the pill. Kept side-effect-free so the test suite can assert it directly.
+    """
+    if review_decision == APPROVED:
+        label = f"✓ Approved #{number}" if number else "✓ Approved"
+        return {"action": "set", "value": label, "icon": PILL_ICON,
+                "color": PILL_COLOR, "priority": PILL_PRIORITY}
+    return {"action": "clear"}
+
+
+def gh_pr_info(cwd):
+    """(reviewDecision, number) for the cwd's branch PR, or (None, None).
+
+    Any failure — no PR, not a repo, gh unauthenticated — is 'no PR'.
+    """
+    r = cx.run(["gh", "pr", "view", "--json", "number,reviewDecision,url"])
+    if r.returncode != 0 or not r.stdout.strip():
+        return None, None
+    try:
+        d = json.loads(r.stdout)
+    except Exception:
+        return None, None
+    return d.get("reviewDecision") or "", d.get("number")
+
+
+def apply(uuid, pill):
+    if pill["action"] == "set":
+        cx.run([cx.CLI, "set-status", STATUS_KEY, pill["value"],
+                "--icon", pill["icon"], "--color", pill["color"],
+                "--priority", pill["priority"], "--workspace", uuid])
+    else:
+        cx.run([cx.CLI, "clear-status", STATUS_KEY, "--workspace", uuid])
+
+
+def main():
+    # Hidden test hook: print the action for a given state without touching cmux.
+    if len(sys.argv) >= 2 and sys.argv[1] == "--emit":
+        decision = sys.argv[2] if len(sys.argv) > 2 else ""
+        number = sys.argv[3] if len(sys.argv) > 3 else ""
+        p = review_pill(decision, number)
+        print(p["action"] if p["action"] == "clear"
+              else "\t".join(["set", p["value"], p["color"], p["priority"]]))
+        return
+
+    if not cx.alive():
+        return
+    # gh runs in the dir the hook fired from.
+    d = cx.read_stdin()
+    cwd = d.get("cwd") or os.getcwd()
+    os.chdir(cwd) if os.path.isdir(cwd) else None
+
+    uuid, _session, _gsid = cx.resolve_workspace(d.get("session_id", ""))
+    if not uuid:
+        return
+    decision, number = gh_pr_info(cwd)
+    apply(uuid, review_pill(decision, number))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass

--- a/configs/claude/scripts/cmux-progress.py
+++ b/configs/claude/scripts/cmux-progress.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Drive the cmux sidebar progress bar from Claude Code's task list.
+
+On every TodoWrite, render completed/total as a 0.0-1.0 sidebar bar labelled
+with the in-progress task — so across many workspaces you can see at a glance
+which agent is 20% vs 90% through a plan or a Ralph/PRD run.
+
+Triggers (see settings.json):
+  PostToolUse(TodoWrite)  — recompute the bar from tool_input.todos
+  SessionStart            — clear the bar (fresh session, no stale fraction)
+
+A finished list sits at 100% until the next TodoWrite resets it or the next
+session clears it. Deliberately NOT cleared on Stop: a mid-task bar must
+survive between turns.
+
+Cosmetic: every failure path exits 0; it must never break a session.
+"""
+import sys, os, json
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import cmux_common as cx
+
+DONE_LABEL = "Done"
+COMPLETED = "completed"
+IN_PROGRESS = "in_progress"
+PENDING = "pending"
+
+
+def _label(todos):
+    """Active-task label: in-progress (activeForm preferred) > next pending > Done."""
+    for want in (IN_PROGRESS, PENDING):
+        for t in todos:
+            if t.get("status") == want:
+                return t.get("activeForm") or t.get("content") or DONE_LABEL
+    return DONE_LABEL
+
+
+def progress_for(todos):
+    """Pure mapping: todo list -> the cmux action to take.
+
+    Returns {"action": "clear"} for an empty list, else
+    {"action": "set", "fraction": <0.0-1.0 str>, "label": <text>}.
+    Side-effect-free so the test suite can assert it directly.
+    """
+    if not todos:
+        return {"action": "clear"}
+    total = len(todos)
+    completed = sum(1 for t in todos if t.get("status") == COMPLETED)
+    return {"action": "set", "fraction": f"{completed / total:.2f}",
+            "label": _label(todos)}
+
+
+def apply(uuid, p):
+    if p["action"] == "set":
+        cx.run([cx.CLI, "set-progress", p["fraction"],
+                "--label", p["label"], "--workspace", uuid])
+    else:
+        cx.run([cx.CLI, "clear-progress", "--workspace", uuid])
+
+
+def main():
+    # Hidden test hook: read a todos JSON array on stdin, print the action.
+    if len(sys.argv) >= 2 and sys.argv[1] == "--emit":
+        try:
+            todos = json.load(sys.stdin)
+        except Exception:
+            todos = []
+        p = progress_for(todos)
+        print(p["action"] if p["action"] == "clear"
+              else "\t".join(["set", p["fraction"], p["label"]]))
+        return
+
+    if not cx.alive():
+        return
+    d = cx.read_stdin()
+    uuid, _session, _gsid = cx.resolve_workspace(d.get("session_id", ""))
+    if not uuid:
+        return
+
+    # SessionStart (or --clear) clears; PostToolUse(TodoWrite) computes.
+    event = d.get("hook_event_name", "")
+    if "--clear" in sys.argv or event == "SessionStart":
+        apply(uuid, {"action": "clear"})
+        return
+    todos = d.get("tool_input", {}).get("todos", [])
+    apply(uuid, progress_for(todos))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass

--- a/configs/claude/scripts/cmux-title.py
+++ b/configs/claude/scripts/cmux-title.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Keep this Claude session's cmux workspace title in sync.
+
+Title auto-tracks the topic: Claude Code sets the terminal *surface* title to a live
+topic summary; this reads it (stripping status glyphs), prefixes the detected Linear
+ticket, and pins it as the workspace title — updating on every turn, no manual step
+required.
+
+Triggers (all wired as hooks; see settings.json):
+  SessionStart / CwdChanged / Stop — stdin {session_id, cwd}
+  Manual override of the topic:  cmux-title.py --topic "short topic"
+
+Title:        "NES-#### · <topic>" — no worktree fallback: before the first
+              topic exists the title is just the ticket (or left untouched when
+              there's no ticket). The description is NOT managed (cmux shows
+              the workspace location natively).
+
+Manual override: remembers the last title it set; if you rename the workspace in
+cmux, the next run sees current != last-set and backs off — your title is kept.
+
+Cosmetic: every failure path exits 0; it must never break a session.
+"""
+import sys, os, re
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import cmux_common as cx
+
+TICKET_RE = re.compile(r"\bNES-\d+\b", re.I)
+import glob, json
+
+
+def detect_ticket(session_id, cwd):
+    """Most-recent NES-#### the USER typed (assistant prose + tool results skipped;
+    injected <system-reminder> context stripped — both are false-positive sources)."""
+    if session_id:
+        hits = glob.glob(os.path.expanduser(f"~/.claude/projects/**/{session_id}.jsonl"), recursive=True)
+        transcript = hits[0] if hits else ""
+    else:
+        proj = os.path.expanduser("~/.claude/projects/" + re.sub(r"[/.]", "-", cwd))
+        js = sorted(glob.glob(proj + "/*.jsonl"), key=os.path.getmtime, reverse=True)
+        transcript = js[0] if js else ""
+    if not transcript or not os.path.isfile(transcript):
+        return ""
+    found = []
+    with open(transcript) as f:
+        for line in f:
+            try:
+                e = json.loads(line)
+            except Exception:
+                continue
+            if e.get("type") != "user":
+                continue
+            c = e.get("message", {}).get("content")
+            if not isinstance(c, str):
+                continue
+            c = re.sub(r"<system-reminder>.*?</system-reminder>", "", c, flags=re.S)
+            found += TICKET_RE.findall(c)
+    return found[-1].upper() if found else ""
+
+
+def surface_topic(uuid, worktree):
+    """The live topic from Claude Code's terminal surface title, cleaned up.
+
+    Returns '' when the title is empty, a path, or just the worktree name — i.e. not
+    yet a real topic — so the caller falls back to the worktree.
+    """
+    # NOTE: raw rpc requires the UUID key "workspace_id"; the friendly "workspace"
+    # key is silently ignored and returns the *focused* workspace instead.
+    try:
+        d = json.loads(cx.run([cx.CLI, "rpc", "surface.list", json.dumps({"workspace_id": uuid})]).stdout)
+    except Exception:
+        return ""
+    for s in d.get("surfaces", []):
+        if s.get("type") != "terminal":
+            continue
+        t = re.sub(r"^[^0-9A-Za-z]+", "", s.get("title", "") or "").strip()
+        if not t or t.startswith("/") or t == worktree or t.lower() in ("zsh", "bash"):
+            return ""
+        return t
+    return ""
+
+
+def main():
+    if not cx.alive():
+        return
+    topic, argv = "", sys.argv[1:]
+    for i, v in enumerate(argv):
+        if v == "--topic" and i + 1 < len(argv):
+            topic = argv[i + 1]
+
+    d = cx.read_stdin()
+    cwd = d.get("cwd") or os.getcwd()
+    uuid, session_id, gsid = cx.resolve_workspace(d.get("session_id", ""))
+    if not uuid:
+        return
+
+    # worktree name — only used by surface_topic to reject not-yet-a-topic titles
+    top = cx.run(["git", "-C", cwd, "rev-parse", "--show-toplevel"]).stdout.strip()
+    worktree = os.path.basename(top or cwd)
+
+    # label: explicit topic > live surface topic. No worktree fallback — the
+    # description already shows worktree+branch, so before the first topic the
+    # title is just the ticket (or untouched when there's no ticket either).
+    label = topic or surface_topic(uuid, worktree)
+    ticket = detect_ticket(session_id, cwd)
+    if label:
+        title = f"{ticket} · {label}" if ticket else label
+    else:
+        title = ticket
+
+    # respect a manual override (state keyed by the terminal)
+    current = next((w.get("title", "") for w in cx.workspaces() if w.get("id") == uuid), "")
+    statefile = os.path.join(cx.MAP_DIR, f"{gsid}.title") if gsid else ""
+    last_set = open(statefile).read() if statefile and os.path.isfile(statefile) else ""
+    if last_set and current != last_set:
+        return
+
+    base = [cx.CLI, "workspace-action", "--workspace", uuid]
+    if title:
+        cx.run(base + ["--action", "rename", "--title", title])
+    if title and statefile:
+        try:
+            with open(statefile, "w") as f:
+                f.write(title)
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass

--- a/configs/claude/scripts/cmux_common.py
+++ b/configs/claude/scripts/cmux_common.py
@@ -1,0 +1,132 @@
+"""Shared cmux helpers for the Claude Code hook scripts.
+
+The crux is identifying *this* session's cmux workspace. Many workspaces share a
+repo cwd and `cmux identify`'s caller is null (→ focused workspace, which drifts),
+so we key off GHOSTTY_SURFACE_ID — inherited by Claude's shell + hooks, stable per
+terminal — mapping it once (at SessionStart, when `selected` is provably ours) to
+{workspace uuid, session id} under ~/.claude/.cmux-titlemap/<gsid>.
+"""
+import os, json, re, subprocess, sys, glob
+
+CLI = "/Applications/cmux.app/Contents/Resources/bin/cmux"
+MAP_DIR = os.path.expanduser("~/.claude/.cmux-titlemap")
+
+
+def run(args):
+    return subprocess.run(args, capture_output=True, text=True)
+
+
+def _socket_path():
+    """Path to cmux's control socket, or '' if we can't determine one.
+
+    Inside a cmux-launched session CMUX_SOCKET_PATH is exported; otherwise fall
+    back to the per-user socket cmux creates while running. A wrong/missing path
+    just means we no-op, which is the safe direction.
+    """
+    p = os.environ.get("CMUX_SOCKET_PATH", "").strip()
+    if p:
+        return p
+    try:
+        return os.path.expanduser(f"~/.local/state/cmux/cmux-{os.getuid()}.sock")
+    except Exception:
+        return ""
+
+
+def alive():
+    """True only when cmux is actually running — every script no-ops otherwise.
+
+    Cheap checks first (CLI present, socket file exists) so a closed cmux — or a
+    non-macOS box without the app — costs nothing: no subprocess is spawned. Only
+    when a socket is present do we exec `cmux ping` to confirm it answers.
+    """
+    if not os.path.exists(CLI):
+        return False
+    sock = _socket_path()
+    if not (sock and os.path.exists(sock)):
+        return False
+    return run([CLI, "ping"]).stdout.strip() == "PONG"
+
+
+def workspaces():
+    try:
+        d = json.loads(run([CLI, "rpc", "workspace.list", "{}"]).stdout)
+    except Exception:
+        return []
+    return (d.get("result") or d).get("workspaces", [])
+
+
+def ghostty_surface_id():
+    g = os.environ.get("GHOSTTY_SURFACE_ID", "").strip()
+    if g:
+        return g
+    try:  # fallback: read the claude ancestor's env
+        pid = os.getppid()
+        for _ in range(8):
+            m = re.search(r"GHOSTTY_SURFACE_ID=(\S+)", run(["ps", "eww", "-p", str(pid)]).stdout)
+            if m:
+                return m.group(1)
+            ppid = run(["ps", "-o", "ppid=", "-p", str(pid)]).stdout.strip()
+            if not ppid or ppid == "1":
+                break
+            pid = int(ppid)
+    except Exception:
+        pass
+    return ""
+
+
+def _map_path(gsid):
+    return os.path.join(MAP_DIR, gsid) if gsid else ""
+
+
+def load_map(gsid):
+    p = _map_path(gsid)
+    if p and os.path.isfile(p):
+        try:
+            return json.load(open(p))
+        except Exception:
+            return {}
+    return {}
+
+
+def save_map(gsid, workspace, session):
+    if not gsid:
+        return
+    try:
+        os.makedirs(MAP_DIR, exist_ok=True)
+        json.dump({"workspace": workspace, "session": session}, open(_map_path(gsid), "w"))
+    except Exception:
+        pass
+
+
+def read_stdin():
+    """Return the hook's stdin JSON as a dict (empty on manual calls)."""
+    if sys.stdin.isatty():
+        return {}
+    try:
+        return json.load(sys.stdin) or {}
+    except Exception:
+        return {}
+
+
+def resolve_workspace(session_hint=""):
+    """Return (workspace_uuid, session_id, gsid) for this session.
+
+    Mapping hit → stored values (robust). Miss → the *selected* workspace (correct
+    at SessionStart) which is then persisted. Returns ('', ...) if undeterminable.
+    """
+    gsid = ghostty_surface_id()
+    m = load_map(gsid)
+    uuid = m.get("workspace", "")
+    session_id = session_hint or m.get("session", "")
+    if not uuid:
+        sel = next((w for w in workspaces() if w.get("selected")), None)
+        if not sel:
+            return "", session_id, gsid
+        uuid = sel.get("id", "")
+        if uuid:
+            save_map(gsid, uuid, session_id)
+    return uuid, session_id, gsid
+
+
+def is_selected(uuid):
+    return any(w.get("selected") and w.get("id") == uuid for w in workspaces())

--- a/configs/claude/scripts/cmux_pr_test.sh
+++ b/configs/claude/scripts/cmux_pr_test.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# cmux_pr_test.sh — regression tests for cmux-pr.py's review-pill mapping.
+# Exercises the pure `review_pill` logic via the script's `--emit` mode
+# (no cmux socket, no network). Run: bash configs/claude/scripts/cmux_pr_test.sh
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+PR="$SCRIPT_DIR/cmux-pr.py"
+
+passed=0
+failed=0
+errors=""
+
+assert_eq() {
+  local test_name="$1" got="$2" want="$3"
+  if [ "$got" = "$want" ]; then
+    passed=$((passed + 1))
+    printf "  \033[38;5;114m✓\033[0m %s\n" "$test_name"
+  else
+    failed=$((failed + 1))
+    errors+="  FAIL: $test_name\n    want: $want\n    got:  $got\n"
+    printf "  \033[38;5;203m✗\033[0m %s\n" "$test_name"
+    printf "    want: %s\n    got:  %s\n" "$want" "$got"
+  fi
+}
+
+emit() { python3 "$PR" --emit "$@"; }
+
+printf "\n\033[38;5;141mcmux-pr.py review-pill mapping\033[0m\n"
+
+assert_eq "APPROVED with number -> set green pill" \
+  "$(emit APPROVED 5)" $'set\t✓ Approved #5\t#3FB950\t20'
+
+assert_eq "APPROVED without number -> set, no #" \
+  "$(emit APPROVED '')" $'set\t✓ Approved\t#3FB950\t20'
+
+assert_eq "CHANGES_REQUESTED -> clear" \
+  "$(emit CHANGES_REQUESTED 5)" "clear"
+
+assert_eq "REVIEW_REQUIRED -> clear" \
+  "$(emit REVIEW_REQUIRED 5)" "clear"
+
+assert_eq "empty decision (no reviews) -> clear" \
+  "$(emit '' 5)" "clear"
+
+# ─── Summary ────────────────────────────────────────────────────────
+total=$((passed + failed))
+printf "\n\033[38;5;141m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m\n"
+if [ "$failed" -eq 0 ]; then
+  printf "\033[38;5;114m✓ All %d tests passed\033[0m\n\n" "$total"
+else
+  printf "\033[38;5;203m✗ %d/%d tests failed\033[0m\n" "$failed" "$total"
+  printf "\n%b\n" "$errors"
+  exit 1
+fi

--- a/configs/claude/scripts/cmux_progress_test.sh
+++ b/configs/claude/scripts/cmux_progress_test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# cmux_progress_test.sh — regression tests for cmux-progress.py's todos->bar map.
+# Exercises the pure `progress_for` logic via the script's `--emit` mode (reads a
+# todos JSON array on stdin). Run: bash configs/claude/scripts/cmux_progress_test.sh
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+PROG="$SCRIPT_DIR/cmux-progress.py"
+
+passed=0
+failed=0
+errors=""
+
+assert_eq() {
+  local test_name="$1" got="$2" want="$3"
+  if [ "$got" = "$want" ]; then
+    passed=$((passed + 1))
+    printf "  \033[38;5;114m✓\033[0m %s\n" "$test_name"
+  else
+    failed=$((failed + 1))
+    errors+="  FAIL: $test_name\n    want: $want\n    got:  $got\n"
+    printf "  \033[38;5;203m✗\033[0m %s\n" "$test_name"
+    printf "    want: %s\n    got:  %s\n" "$want" "$got"
+  fi
+}
+
+emit() { printf '%s' "$1" | python3 "$PROG" --emit; }
+
+printf "\n\033[38;5;141mcmux-progress.py todos->bar mapping\033[0m\n"
+
+assert_eq "empty list -> clear" \
+  "$(emit '[]')" "clear"
+
+assert_eq "all pending -> 0.00, label = first pending activeForm" \
+  "$(emit '[{"content":"A","activeForm":"Doing A","status":"pending"},{"content":"B","status":"pending"}]')" \
+  $'set\t0.00\tDoing A'
+
+assert_eq "1 of 3 done, 1 in_progress -> 0.33, in_progress label" \
+  "$(emit '[{"content":"A","status":"completed"},{"content":"B","activeForm":"Building B","status":"in_progress"},{"content":"C","status":"pending"}]')" \
+  $'set\t0.33\tBuilding B'
+
+assert_eq "in_progress without activeForm -> falls back to content" \
+  "$(emit '[{"content":"Raw content","status":"in_progress"}]')" \
+  $'set\t0.00\tRaw content'
+
+assert_eq "all complete -> 1.00, label Done" \
+  "$(emit '[{"content":"A","status":"completed"},{"content":"B","status":"completed"}]')" \
+  $'set\t1.00\tDone'
+
+assert_eq "multiple in_progress -> takes the first" \
+  "$(emit '[{"content":"A","activeForm":"First","status":"in_progress"},{"content":"B","activeForm":"Second","status":"in_progress"}]')" \
+  $'set\t0.00\tFirst'
+
+# ─── Summary ────────────────────────────────────────────────────────
+total=$((passed + failed))
+printf "\n\033[38;5;141m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m\n"
+if [ "$failed" -eq 0 ]; then
+  printf "\033[38;5;114m✓ All %d tests passed\033[0m\n\n" "$total"
+else
+  printf "\033[38;5;203m✗ %d/%d tests failed\033[0m\n" "$failed" "$total"
+  printf "\n%b\n" "$errors"
+  exit 1
+fi

--- a/configs/claude/scripts/cmux_status_demo.sh
+++ b/configs/claude/scripts/cmux_status_demo.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# cmux_status_demo.sh — visual demo of the cmux sidebar pill + progress bar.
+# Drives the REAL cmux against the current workspace so you can eyeball each
+# rendering. No-ops with a message when not running inside cmux.
+# Run: bash configs/claude/scripts/cmux_status_demo.sh
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+CLI="/Applications/cmux.app/Contents/Resources/bin/cmux"
+WS="${CMUX_WORKSPACE_ID:-}"
+PAUSE="${DEMO_PAUSE:-1.5}"
+
+if [ ! -x "$CLI" ] || [ "$($CLI ping 2>/dev/null)" != "PONG" ] || [ -z "$WS" ]; then
+  echo "Not inside a live cmux workspace — nothing to demo."
+  exit 0
+fi
+
+say() { printf "\n\033[38;5;141m▶ %s\033[0m\n" "$1"; }
+
+say "review pill: APPROVED  (look for '✓ Approved #42' in the sidebar)"
+"$CLI" set-status review "✓ Approved #42" --icon checkmark.seal.fill \
+  --color "#3FB950" --priority 20 --workspace "$WS"; sleep "$PAUSE"
+
+say "review pill: cleared  (CHANGES_REQUESTED / no PR — pill disappears)"
+"$CLI" clear-status review --workspace "$WS"; sleep "$PAUSE"
+
+say "progress bar: advancing 20% -> 100%"
+for f in 0.20 0.40 0.60 0.80 1.00; do
+  "$CLI" set-progress "$f" --label "step @ ${f}" --workspace "$WS"; sleep "$PAUSE"
+done
+
+say "progress bar: cleared  (empty todo list / fresh session)"
+"$CLI" clear-progress --workspace "$WS"
+
+say "done — sidebar restored to idle"

--- a/configs/claude/settings.json
+++ b/configs/claude/settings.json
@@ -96,6 +96,18 @@
             "command": "python3 \"$HOME/.claude/scripts/cmux-title.py\"",
             "timeout": 10,
             "statusMessage": "Setting cmux workspace title"
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/scripts/cmux-pr.py\"",
+            "timeout": 10,
+            "async": true
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/scripts/cmux-progress.py\"",
+            "timeout": 10,
+            "async": true
           }
         ]
       }
@@ -118,6 +130,36 @@
           {
             "type": "command",
             "command": "python3 \"$HOME/.claude/scripts/cmux-title.py\"",
+            "timeout": 10,
+            "async": true
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/scripts/cmux-pr.py\"",
+            "timeout": 10,
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "TodoWrite",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/.claude/scripts/cmux-progress.py\"",
+            "timeout": 10,
+            "async": true
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.command // \"\"' | grep -qE 'git +push|gh +pr +create' && python3 \"$HOME/.claude/scripts/cmux-pr.py\" </dev/null || true",
             "timeout": 10,
             "async": true
           }
@@ -234,6 +276,5 @@
         "TAVILY_API_KEY": "${TAVILY_API_KEY}"
       }
     }
-  },
-  "model": "claude-fable-5[1m]"
+  }
 }

--- a/script/claude/setup.sh
+++ b/script/claude/setup.sh
@@ -27,6 +27,8 @@ link_file "$SCRIPT_DIR/../../configs/claude/prompts/" "$HOME/.claude/prompts" "d
 link_file "$SCRIPT_DIR/../../configs/claude/statusline.sh" "$HOME/.claude/statusline.sh"
 link_file "$SCRIPT_DIR/../../configs/claude/settings.json" "$HOME/.claude/settings.json"
 link_file "$SCRIPT_DIR/../../configs/claude/hooks/" "$HOME/.claude/hooks"
+# cmux sidebar hook scripts (workspace title, PR-approval pill, task progress bar)
+link_file "$SCRIPT_DIR/../../configs/claude/scripts/" "$HOME/.claude/scripts" "directory"
 
 # Touch ID command gate (macOS): compile the bioprompt helper used by the
 # touchid-gate.py PreToolUse hook to biometric-gate sensitive Bash commands.


### PR DESCRIPTION
## What

Two new Claude Code hook scripts that drive the cmux sidebar via the native CLI, plus version-control plumbing for the cmux hook scripts (they previously lived only in \`~/.claude/scripts\`, untracked).

- **\`cmux-pr.py\`** — \`✓ Approved #<n>\` status pill when the branch's PR is approved (CI is left to cmux's native PR watcher). Refresh on \`SessionStart\` / \`Stop\` / after \`git push\`/\`gh pr create\`.
- **\`cmux-progress.py\`** — \`TodoWrite\`-driven sidebar progress bar (\`completed/total\`), cleared on \`SessionStart\`.
- **\`cmux_common.alive()\`** — short-circuits on socket existence so every hook script no-ops cheaply (no subprocess) when cmux isn't running or off-macOS.
- Moved \`cmux_common.py\` + \`cmux-title.py\` into \`configs/claude/scripts/\`; linked the dir in \`script/claude/setup.sh\`.

## Tests

- \`cmux_pr_test.sh\` (5/5) and \`cmux_progress_test.sh\` (6/6) — pure mapping logic via a hidden \`--emit\` mode, no cmux/network needed.
- \`cmux_status_demo.sh\` — live visual demo inside cmux.

## Notes

- Also carries a pre-existing one-line \`model\` pin removal that was already in the working tree.